### PR TITLE
[남기]Fix: 메뉴판 예외처리 및 장바구니 옵션수량 에러 수정

### DIFF
--- a/src/components/cartlist/CartList.css
+++ b/src/components/cartlist/CartList.css
@@ -4,15 +4,6 @@
  * 전역 변수 정의
  * - 장바구니 컴포넌트에서 사용되는 공통 색상 및 스타일 변수
  */
- :root {
-  --primary-light: #C0C78C;    /* 밝은 주색상 */
-  --primary: #A6B37D;          /* 주색상 */
-  --background: #FEFAE0;       /* 배경색 */
-  --text: #B99470;            /* 텍스트 색상 */
-  --danger: #dc3545;          /* 경고/삭제 색상 */
-  --border-color: #eee;       /* 경계선 색상 */
-  --shadow: rgba(0, 0, 0, 0.1); /* 그림자 색상 */
-}
 
 /**
  * 장바구니 컨테이너
@@ -112,7 +103,7 @@
 .item-title {
   font-size: 1.25rem;
   font-weight: bold;
-  color: var(--text);
+  color:#B99470;  
   margin-bottom: 0.5rem;
 }
 
@@ -167,7 +158,7 @@
 }
 
 .quantity-button:hover {
-  background-color: var(--primary-light);
+  background-color: #C0C78C; 
 }
 
 .quantity-display {

--- a/src/components/cartlist/CartList.jsx
+++ b/src/components/cartlist/CartList.jsx
@@ -36,7 +36,7 @@ function CartList({closeCartModal}) {
     const newCart = cartItems.map((item, i) => {
       if (i === index) {
         const basePrice = item.price + 
-          (item.selectedOptions?.reduce((sum, opt) => sum + (opt.optionPrice || 0), 0) || 0);
+          (item.selectedOptions?.reduce((sum, opt) => sum + (opt.optionPrice*opt.quantity || 0), 0) || 0);
         return {
           ...item,
           quantity: newQuantity,
@@ -125,7 +125,7 @@ function CartList({closeCartModal}) {
                           + {option.optionName}
                           {option.optionPrice > 0 && 
                             ` (${option.optionPrice.toLocaleString()}원)`
-                          }
+                          } + {option.quantity}
                         </div>
                       ))}
                     </div>

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -127,17 +127,17 @@ const Layout = () => {
 
                             {/* 장바구니 버튼 */}
                             <li className="nav-item ms-3">
-                                <button
+                                {user ? <button
                                     className="cart-button"
                                     onClick={openCartModal}
                                     aria-label="장바구니 열기"
                                 >
                                     장바구니 보기
-                                </button>
-                            {/* 로그아웃 버튼 */}    
-                            {user ? <button className='cart-button'
-                                onClick={logoutHandler}>Logout</button>
-                            : ""}
+                                </button> : ""}
+                                {/* 로그아웃 버튼 */}
+                                {user ? <button className='cart-button'
+                                    onClick={logoutHandler}>Logout</button>
+                                    : ""}
 
                             </li>
                         </ul>

--- a/src/pages/product/ProductDetailPage.jsx
+++ b/src/pages/product/ProductDetailPage.jsx
@@ -225,6 +225,7 @@ export default function ProductDetailPage() {
       productName: product.productName,
       price: product.price,
       imageUrl: product.imageUrl,
+      quantity : 1,
       selectedOptions: selectedOptions.length > 0 ? selectedOptions.map(opt => ({
         ...opt,
         quantity: optionQuantities[opt.optionName]
@@ -248,21 +249,26 @@ export default function ProductDetailPage() {
       
       // 모든 옵션의 이름이 같은지 확인
       return sortedExistingOptions.every((opt, index) => 
-        opt.optionName === sortedNewOptions[index].optionName
+        opt.optionName === sortedNewOptions[index].optionName && 
+        opt.quantity === sortedNewOptions[index].quantity
       );
     });
+    console.log(existingItemIndex + "번 상품 중복");
+    
 
     if (existingItemIndex >= 0) {
       // 동일한 옵션 조합을 가진 상품이 있으면 수량만 증가
       const existingItem = cart[existingItemIndex];
-      cartItem.selectedOptions.forEach(newOpt => {
-        const existingOpt = existingItem.selectedOptions
-          .find(opt => opt.optionName === newOpt.optionName);
-        if (existingOpt) {
-          existingOpt.quantity += newOpt.quantity;
-        }
-      });
-      existingItem.totalPrice = calculateTotalPrice();
+      existingItem.quantity += cartItem.quantity;
+      
+      // cartItem.selectedOptions.forEach(newOpt => {
+      //   const existingOpt = existingItem.selectedOptions
+      //     .find(opt => opt.optionName === newOpt.optionName);
+      //   if (existingOpt) {
+      //     existingOpt.quantity += newOpt.quantity;
+      //   }
+      // });
+      existingItem.totalPrice += cartItem.totalPrice
     } else {
       // 새로운 옵션 조합이면 새 아이템으로 추가
       cart.push(cartItem);

--- a/src/pages/user/LoginPage.jsx
+++ b/src/pages/user/LoginPage.jsx
@@ -69,6 +69,7 @@ function LoginPage() {
         if (valid) {
             // 로그인 함수 호출
             Login(id, password)
+            localStorage.removeItem('cart');
         }
     }
     /////////////////////////////////////////////////////////


### PR DESCRIPTION
## 예외처리 완료
1. 로그인시 
    로컬스토리지 Cart 삭제되어야함  >>>>>>>>>> 해결  

2. 메뉴판
+ 동일한 상품 여러번 추가시  >>>>>>>>>>>>>>>> 해결  
    + 현재는 중복제거돼서 장바구니에 추가가 안됨
    + 장바구니에서 동일상품 갯수가 증가하도록 변경   
+ 메뉴판에서 아메(시럽 옵션 1회추가)을 여러번 추가시 >>>>>>>>>>>>>>>> 해결  
	+ 현재는 장바구니에 기존메뉴의 옵션수가 늘어남 (아메리카노 시럽30회추가 1잔 이딴식으로 저장됨)  
	+ 정상적으로 상품 갯수가 증가하도록 변경 (시럽1회 아메 30잔)  
+ 동일한메뉴, 동일한 옵션이지만 옵션의 횟수가 다른 메뉴 추가시 >>>>>>>>>>>>>>>> 해결  
    + 현재는 중복으로 판단
    + 해결 

3. 장바구니
    + 장바구니에서 수량 추가시 옵션갯수를 totalprice에 반영하지 않음 >>>>>>>> 해결  
    + 장바구니에 옵션수량 보이도록 수정 >>>>>>> 해결 (임시)


## 미완료
4. 메뉴판페이지 : ice hot 옵션도 선택 할 수 있게 변경
5. 메뉴판페이지 : large 등 사이즈 옵션은 한번만 선택 가능하도록 수정

6. 새로고침했을때 css 개지랄나는거 수정해야됨