### PR TITLE
[남희] Style: 관리자 페이지 css 적용 12.24

### DIFF
--- a/src/pages/adminPage/AdminMain.css
+++ b/src/pages/adminPage/AdminMain.css
@@ -1,0 +1,129 @@
+:root {
+    --page-bg: #FEFAE0;
+    --primary-color: #A6B37D;
+    --secondary-color: #B99470;
+    --accent-color: #C0C78C;
+    --text-dark: #333333;
+    --text-light: #FFFFFF;
+    --spacing-unit: 1rem;
+    --transition-speed: 0.3s;
+    --container-max-width: 1200px;
+  }
+  
+  .page-wrapper {
+    min-height: 100vh;
+    background-color: var(--page-bg);
+  }
+  
+  .container {
+    max-width: var(--container-max-width);
+    margin: 0 auto;
+    padding: 0 calc(var(--spacing-unit) * 1.5);
+  }
+  
+  .table {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-top: var(--spacing-unit);
+    text-align: center;
+  }
+  
+  .table thead {
+    background-color: var(--accent-color);
+  }
+  
+  .table th {
+    color: #B99470;
+    font-weight: 600;
+    padding: calc(var(--spacing-unit) * 0.8);
+    border-bottom: none;
+  }
+  
+  .table td {
+    color: #B99470;
+    padding: calc(var(--spacing-unit) * 0.8);
+    vertical-align: middle;
+  }
+  
+  .table tbody tr:hover {
+    background-color: rgba(192, 199, 140, 0.1);
+  }
+  
+  /* .btn-primary {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--text-light);
+    transition: all var(--transition-speed) ease;
+  }
+  
+  .btn-primary:hover {
+    background-color: var(--secondary-color);
+    border-color: var(--secondary-color);
+    transform: translateY(-1px);
+  } */
+  
+  .btn-secondary {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: var(--text-light);
+    transition: all var(--transition-speed) ease;
+  }
+  
+  .btn-secondary:hover {
+    background-color: var(--secondary-color);
+    border-color: var(--secondary-color);
+    transform: translateY(-1px);
+  }
+  
+  .btn-danger {
+    background-color: #dc3545;
+    transition: all var(--transition-speed) ease;
+  }
+  
+  .btn-danger:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(220, 53, 69, 0.2);
+  }
+  
+  .d-flex {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-unit);
+  }
+  
+  .button-group {
+    display: flex;
+    gap: 0.5rem;
+  }
+  
+  h2 {
+    color: #B99470;
+    text-align: center;
+    font-weight: bolder;
+    margin-bottom: 30px;
+    /* color: var(--text-dark); */
+  }
+  
+  @media (max-width: 992px) {
+    .container {
+      padding: 0 var(--spacing-unit);
+    }
+  }
+  
+  @media (max-width: 768px) {
+    .d-flex {
+      flex-direction: column;
+    }
+    
+    .btn {
+      width: 100%;
+      margin-bottom: calc(var(--spacing-unit) * 0.5);
+    }
+  }
+  
+  @media (max-width: 576px) {
+    .container {
+      padding: 0 calc(var(--spacing-unit) * 0.5);
+    }
+  }

--- a/src/pages/adminPage/AdminMain.jsx
+++ b/src/pages/adminPage/AdminMain.jsx
@@ -5,6 +5,8 @@ import axios from 'axios';
 
 export default function AdminMain() {
   const [orders, setOrders] = useState([]);
+  const [allOrders, setAllOrders] = useState([]); // 전체 주문 목록을 저장할 상태
+  const [showAll, setShowAll] = useState(false); // 전체 목록을 볼지, 오늘의 주문만 볼지 상태
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -19,10 +21,27 @@ export default function AdminMain() {
           access: access, // 인증 헤더 설정
         },
       });
-      setOrders(response.data);
+      
+      setAllOrders(response.data); // 전체 주문 목록 저장
+      filterTodayOrders(response.data); // 오늘 주문만 필터링
     } catch (error) {
       console.error('주문 목록 조회 실패:', error);
     }
+  };
+
+  const filterTodayOrders = (orders) => {
+    // 오늘 날짜 기준으로 필터링
+    const today = new Date();
+    const filteredOrders = orders.filter(order => {
+      const orderedAt = new Date(order.orderedAt);
+      return (
+        orderedAt.getDate() === today.getDate() &&
+        orderedAt.getMonth() === today.getMonth() &&
+        orderedAt.getFullYear() === today.getFullYear()
+      );
+    });
+    
+    setOrders(filteredOrders); // 오늘의 주문만 상태에 저장
   };
 
   const handleDelete = async (orderId) => {
@@ -41,6 +60,15 @@ export default function AdminMain() {
     }
   };
 
+  const toggleOrderView = () => {
+    setShowAll(!showAll);
+    if (!showAll) {
+      setOrders(allOrders); // 전체 주문 목록으로 설정
+    } else {
+      filterTodayOrders(allOrders); // 오늘의 주문만 필터링
+    }
+  };
+
   return (
     <div>
       <div className="d-flex justify-content-between mb-4">
@@ -50,6 +78,12 @@ export default function AdminMain() {
           onClick={() => navigate('/admin/menu')}
         >
           메뉴 관리
+        </button>
+        <button
+          className="btn btn-secondary"
+          onClick={toggleOrderView}
+        >
+          {showAll ? '오늘의 주문만 보기' : '전체 주문 보기'}
         </button>
       </div>
 

--- a/src/pages/adminPage/AdminMain.jsx
+++ b/src/pages/adminPage/AdminMain.jsx
@@ -1,4 +1,5 @@
 // pages/AdminMain.jsx
+import './AdminMain.css';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
@@ -70,56 +71,61 @@ export default function AdminMain() {
   };
 
   return (
-    <div>
-      <div className="d-flex justify-content-between mb-4">
-        <h2>주문 관리</h2>
-        <button 
-          className="btn btn-primary"
-          onClick={() => navigate('/admin/menu')}
-        >
-          메뉴 관리
-        </button>
-        <button
-          className="btn btn-secondary"
-          onClick={toggleOrderView}
-        >
-          {showAll ? '오늘의 주문만 보기' : '전체 주문 보기'}
-        </button>
+    <div className='page-wrapper'>
+      <div className='container'>
+        <div>
+          <h2>주문 관리</h2>
+          <div className="d-flex mb-4">
+            <div className='button-group'>
+              <button 
+                className="btn btn-secondary"
+                onClick={() => navigate('/admin/menu')}
+              >
+                메뉴 관리
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={toggleOrderView}
+              >
+                {showAll ? '오늘의 주문만 보기' : '전체 주문 보기'}
+              </button>
+            </div>
+          </div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>주문 ID</th>
+                <th>사용자</th>
+                <th>mmid</th>
+                <th>총 금액</th>
+                {/* <th>주문 상태</th> */}
+                <th>주문 시간</th>
+                <th>취소</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map(order => (
+                <tr key={order.orderID}>
+                  <td>{order.orderID}</td>
+                  <td>{order.name}</td>
+                  <td>{order.mmid}</td>
+                  <td>{order.totalPrice.toLocaleString()}원</td>
+                  {/* <td>{order.isCancel ? '취소됨' : '정상'}</td> */}
+                  <td>{new Date(order.orderedAt).toLocaleString()}</td>
+                  <td>
+                    <button
+                      className="btn btn-danger btn-sm"
+                      onClick={() => handleDelete(order.orderID)}
+                    >
+                      삭제
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
-
-      <table className="table">
-        <thead>
-          <tr>
-            <th>주문 ID</th>
-            <th>사용자</th>
-            <th>mmid</th>
-            <th>총 금액</th>
-            {/* <th>주문 상태</th> */}
-            <th>주문 시간</th>
-            <th>취소</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map(order => (
-            <tr key={order.orderID}>
-              <td>{order.orderID}</td>
-              <td>{order.name}</td>
-              <td>{order.mmid}</td>
-              <td>{order.totalPrice.toLocaleString()}원</td>
-              {/* <td>{order.isCancel ? '취소됨' : '정상'}</td> */}
-              <td>{new Date(order.orderedAt).toLocaleString()}</td>
-              <td>
-                <button
-                  className="btn btn-danger btn-sm"
-                  onClick={() => handleDelete(order.orderID)}
-                >
-                  삭제
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }

--- a/src/pages/adminPage/MenuManagement.css
+++ b/src/pages/adminPage/MenuManagement.css
@@ -1,0 +1,164 @@
+/* MenuManagement.css */
+:root {
+    --page-bg: #FEFAE0;
+    --primary-color: #A6B37D;
+    --secondary-color: #B99470;
+    --accent-color: #C0C78C;
+    --text-dark: #333333;
+    --text-light: #FFFFFF;
+    --spacing-unit: 1rem;
+    --transition-speed: 0.3s;
+    --container-max-width: 1200px;
+  }
+  
+  .page-wrapper {
+    min-height: 100vh;
+    background-color: var(--page-bg);
+  }
+  
+  .container {
+    max-width: var(--container-max-width);
+    margin: 0 auto;
+    padding: 0 calc(var(--spacing-unit) * 1.5);
+  }
+  
+  .menu-management-container {
+    min-height: 100vh;
+    background-color: var(--page-bg);
+    padding: calc(var(--spacing-unit) * 2);
+  }
+  
+  .menu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: calc(var(--spacing-unit) * 2);
+  }
+  
+  .menu-header h2 {
+    color: var(--secondary-color);
+    font-weight: 700;
+    margin: 0;
+  }
+  
+  .menu-table {
+    background-color: var(--text-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+  }
+  
+  .menu-table thead {
+    background-color: var(--accent-color);
+  }
+  
+  .menu-table th {
+    color: var(--secondary-color);
+    font-weight: 600;
+    padding: calc(var(--spacing-unit) * 0.8);
+    text-align: center;
+    border: none;
+  }
+  
+  .menu-table td {
+    color: var(--secondary-color);
+    padding: calc(var(--spacing-unit) * 0.8);
+    text-align: center;
+    vertical-align: middle;
+  }
+  
+  .menu-table tbody tr:hover {
+    background-color: rgba(192, 199, 140, 0.1);
+    transition: background-color var(--transition-speed) ease;
+  }
+  
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: all var(--transition-speed) ease;
+  }
+  
+  .btn-primary {
+    background-color: var(--primary-color);
+    border: none;
+    color: var(--text-light);
+  }
+  
+  .btn-primary:hover {
+    background-color: var(--secondary-color);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(185, 148, 112, 0.2);
+  }
+  
+  .btn-warning {
+    background-color: var(--accent-color);
+    border: none;
+    color: var(--text-light);
+  }
+  
+  .btn-warning:hover {
+    background-color: var(--secondary-color);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(185, 148, 112, 0.2);
+  }
+  
+  .btn-danger {
+    background-color: #dc3545;
+    border: none;
+    color: var(--text-light);
+  }
+  
+  .btn-danger:hover {
+    background-color: #c82333;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(220, 53, 69, 0.2);
+  }
+  
+  .btn-sm {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+  }
+  
+  .me-2 {
+    margin-right: 0.5rem;
+  }
+
+  h2 {
+    color: #B99470;
+    text-align: center;
+    font-weight: bolder;
+    margin-bottom: 30px;
+  }
+  
+  @media (max-width: 992px) {
+    .menu-management-container {
+      padding: var(--spacing-unit);
+    }
+  }
+  
+  @media (max-width: 768px) {
+    .menu-header {
+      flex-direction: column;
+      gap: var(--spacing-unit);
+      text-align: center;
+    }
+  
+    .btn {
+      width: 100%;
+    }
+  
+    .menu-table {
+      overflow-x: auto;
+    }
+  }
+  
+  @media (max-width: 576px) {
+    .menu-management-container {
+      padding: calc(var(--spacing-unit) * 0.5);
+    }
+    
+    .btn-sm {
+      width: auto;
+    }
+  }

--- a/src/pages/adminPage/MenuManagement.jsx
+++ b/src/pages/adminPage/MenuManagement.jsx
@@ -1,4 +1,5 @@
 // pages/MenuManagement.jsx
+import './MenuManagement.css';
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import ProductModal from '../../components/adminPage/ProductModal';
@@ -103,60 +104,62 @@ export default function MenuManagement() {
   
 
   return (
-    <div>
-      <div className="d-flex justify-content-between mb-4">
+    <div className='page-wrapper'>
+      <div className='container'>
         <h2>메뉴 관리</h2>
-        <button 
-          className="btn btn-primary"
-          onClick={handleAdd}
-        >
-          메뉴 추가
-        </button>
-      </div>
+        <div className="d-flex mb-4">
+          <button 
+            className="btn btn-primary"
+            onClick={handleAdd}
+          >
+            메뉴 추가
+          </button>
+        </div>
 
-      <table className="table">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>메뉴명</th>
-            <th>가격</th>
-            <th>카테고리</th>
-            <th>작업</th>
-          </tr>
-        </thead>
-        <tbody>
-          {products.map(product => (
-            <tr key={product.productId}>
-              <td>{product.productId}</td>
-              <td>{product.productName}</td>
-              <td>{product.price.toLocaleString()}원</td>
-              <td>{product.category}</td>
-              <td>
-                <button
-                  className="btn btn-warning btn-sm me-2"
-                  onClick={() => handleEdit(product.productId)}
-                >
-                  수정
-                </button>
-                <button
-                  className="btn btn-danger btn-sm"
-                  onClick={() => handleDelete(product.productId)}
-                >
-                  삭제
-                </button>
-              </td>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>메뉴명</th>
+              <th>가격</th>
+              <th>카테고리</th>
+              <th>작업</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {products.map(product => (
+              <tr key={product.productId}>
+                <td>{product.productId}</td>
+                <td>{product.productName}</td>
+                <td>{product.price.toLocaleString()}원</td>
+                <td>{product.category}</td>
+                <td>
+                  <button
+                    className="btn btn-warning btn-sm me-2"
+                    onClick={() => handleEdit(product.productId)}
+                  >
+                    수정
+                  </button>
+                  <button
+                    className="btn btn-danger btn-sm"
+                    onClick={() => handleDelete(product.productId)}
+                  >
+                    삭제
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
 
-      <ProductModal
-        show={showModal}
-        handleClose={() => setShowModal(false)}
-        product={selectedProduct}
-        handleSubmit={handleSubmit}
-        mode={modalMode}
-      />
+        <ProductModal
+          show={showModal}
+          handleClose={() => setShowModal(false)}
+          product={selectedProduct}
+          handleSubmit={handleSubmit}
+          mode={modalMode}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 1. 관리자 주문내역 페이지 날짜 필터링 기능 추가
- 전체 주문내역
![image](https://github.com/user-attachments/assets/aaeac525-8d61-46b4-adb9-92392aec8681)
- 오늘 주문내역
![image](https://github.com/user-attachments/assets/7a421b04-dedf-4576-9b37-b33ddd8e7e77)

## 2. 관리자 페이지 CSS 적용
![image](https://github.com/user-attachments/assets/e1c8601d-4423-4d74-96bc-bbda68d4f26d)

## develop
#### 관리자 페이지 중, 메뉴 관리 페이지 제거 고려 중
다음과 같이 role에 따라 메인페이지 '상품 추가' 버튼 노출되는 걸로 대체할 예정
![image](https://github.com/user-attachments/assets/abef9b75-025c-43af-bac6-989437dfdeb0)
![image](https://github.com/user-attachments/assets/82bfdd68-329b-4e52-b272-8d2347b0d6de)
