### PR TITLE
[남희] Feat: navbar에 관리자 페이지 라우팅 버튼 추가 12.25

### DIFF
--- a/src/pages/Navbar.jsx
+++ b/src/pages/Navbar.jsx
@@ -4,6 +4,7 @@ import Modal from '../components/cartlist/Modal';
 import CartList from '../components/cartlist/CartList';
 import { getUser } from '../apis/userapis/getuser';
 import { logout } from '../apis/userapis/logout';
+import { isStaff } from '../apis/userapis/isStaff';
 import styles from './Navbar.module.css';
 
 const Navbar = () => {
@@ -11,12 +12,15 @@ const Navbar = () => {
   const [isCartModalOpen, setCartModalOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+  const [isStaffStatus, setIsStaffStatus] = useState(false);
 
   // Fetch user information when the component mounts or updates
   useEffect(() => {
     const fetchUser = async () => {
       const res = await getUser();
+      const staffCheck = await isStaff();  // 관리자 navbar
       setUser(res);
+      setIsStaffStatus(staffCheck);
     };
     fetchUser();
   }, [location.pathname]); // 사용자 상태를 경로 변경에 따라 업데이트
@@ -59,6 +63,20 @@ const Navbar = () => {
         >
           마이페이지
         </NavLink>
+
+        {/* 관리자 전용 링크 */}
+        {isStaffStatus && (
+          <NavLink
+            to="/admin"
+            className={({ isActive }) =>
+              isActive ? `${styles.navbarLink} ${styles.active}` : styles.navbarLink
+            }
+          >
+            관리자
+          </NavLink>
+        )}
+
+      
         {user ? (
           <>
             <button

--- a/src/pages/adminPage/MenuManagement.jsx
+++ b/src/pages/adminPage/MenuManagement.jsx
@@ -1,6 +1,7 @@
 // pages/MenuManagement.jsx
 import styles from './MenuManagement.module.css';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import ProductModal from '../../components/adminPage/ProductModal';
 import 'bootstrap/dist/css/bootstrap.min.css'; 
@@ -10,6 +11,7 @@ export default function MenuManagement() {
   const [showModal, setShowModal] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [modalMode, setModalMode] = useState('add');
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchProducts();
@@ -110,6 +112,12 @@ export default function MenuManagement() {
         <div className={styles.contentContainer}>
           <h2 className={styles.h2}>메뉴 관리</h2>
           <div className={`${styles.flex} ${styles.mb4}`}>
+            <button 
+              className={styles.menuAddBtn}
+              onClick={() => navigate('/admin')}
+            >
+              주문 관리
+            </button>
             <button 
               className={styles.menuAddBtn}
               onClick={handleAdd}

--- a/src/pages/adminPage/MenuManagement.module.css
+++ b/src/pages/adminPage/MenuManagement.module.css
@@ -106,6 +106,11 @@
   margin-bottom: 3px;
 }
 
+.menuAddBtn:hover {
+  background-color: #B99470;
+  transform: translateY(-1px);
+}
+
 .btnPrimary {
   background-color: #A6B37D;
   border: none;


### PR DESCRIPTION
## 1. navbar에 관리자 페이지 라우팅 버튼 추가
```javascript
{/* 관리자 전용 링크 */}
{isStaffStatus && (
  <NavLink
    to="/admin"
    className={({ isActive }) =>
      isActive ? `${styles.navbarLink} ${styles.active}` : styles.navbarLink
    }
  >
    관리자
  </NavLink>
)}
```
- 관리자일 경우
![image](https://github.com/user-attachments/assets/e2c4509c-7064-4743-880f-a81b497cd32d)
- 일반 사용자 경우
![image](https://github.com/user-attachments/assets/54bff7fc-74ea-4dd2-8c62-9215c5faedaa)

## 2. 관리자 페이지 - '주문 관리' 버튼 추가
![image](https://github.com/user-attachments/assets/b1e98d96-9d13-45af-9f29-eaf1b7015814)
